### PR TITLE
Workaround for crash on exit

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -70,5 +70,15 @@ int main()
 
 	Love::Exit(L);
 
+	//Crash on exit workaround
+        gfxInitDefault();
+        consoleInit(NULL);
+        printf("\x1b[40;64HPress the home button to exit");
+        while(true){
+                gfxFlushBuffers();
+                gfxSwapBuffers();
+                gfxWaitForVsync();
+        }
+
 	return 0;
 }


### PR DESCRIPTION
Never returns, prevents svcBreak from being called. Should probably be replaced when a better solution comes around. Requires the user to press the home button to exit, but far more elegant than requiring each developer to implement their own "press the home button" message.