### PR TITLE
Modify circle with transformation stack

### DIFF
--- a/source/modules/graphics.cpp
+++ b/source/modules/graphics.cpp
@@ -458,6 +458,8 @@ int Graphics::Circle(lua_State * L)
 
     float radius = luaL_checknumber(L, 4);
 
+    transformDrawable(&x, &y);
+
     if (mode == "fill")
         filledCircleRGBA(Window::GetRenderer(), x, y, radius, drawColor.r, drawColor.g, drawColor.b, drawColor.a);
     else if (mode == "line")


### PR DESCRIPTION
Fix a bug in which love.graphics.circle was not modified by the transformation stack

I will be testing this change with the artifacts created by Doozer. For the moment, do not merge.