### PR TITLE
Fix the rectangle crash and update some functions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ include $(DEVKITARM)/3ds_rules
 INC_OBJS	:= $(sort $(dir $(wildcard include/objects/*/)))
 SRC_OBJS	:= $(sort $(dir $(wildcard source/objects/*/)))
 LUASOCKET	:= $(sort $(dir $(wildcard source/socket/objects/*/*)))
-EXT_LIBS    := libraries/lua
+EXT_LIBS    := libraries/lua libraries/luaobj
 
 TARGET			:=	LovePotion
 BUILD			:=	build
@@ -89,7 +89,7 @@ CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++14
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:=  -llua -lluajit -lSDL_mixer -lmikmod -lmad -lvorbisidec -logg `sdl-config --libs` -ljansson -lpng -lz -lcitro2d -lcitro3d -lctru -lm
+LIBS	:= -lluajit -lSDL_mixer -lmikmod -lmad -lvorbisidec -logg `sdl-config --libs` -ljansson -lpng -lz -lcitro2d -lcitro3d -lctru -lm
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
@@ -194,7 +194,7 @@ endif
 
 #---------------------------------------------------------------------------------
 all: $(BUILD) $(GFXBUILD) $(DEPSDIR) $(ROMFS_T3XFILES) $(T3XHFILES)
-	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
+	@$(MAKE) --no-print-directory --silent -C $(BUILD) -f $(CURDIR)/Makefile
 
 $(BUILD):
 	@mkdir -p $@


### PR DESCRIPTION
This fixes the hard crash caused whenever the user tries to use the `love.graphics.rectangle` function. However, there are some known bugs with the implementation in its current state:

- Using `love.graphics.print` causes the rectangle to not display. Not tested with images.
- The transformation stack does not apply rotation to either the filled or lined rectangle, and does not scale or translate the lined rectangle.

I also updated some miscellaneous things. `love.graphics.setColor` and `love.graphics.setBackgroundColor` now require the red, green, and blue components. The Makefile now only prints the name of the file that is being compiled. Lua and LuaOBJ are now properly linked in the Makefile.

P.S.
The crash was being caused by Transform getting a pointer with the value of 0 (zero). Not a pointer to a number 0, the pointer was just the number 0. The 3DS was trying to modify whatever value was at 0x0 in memory, which probably wasn't something it was ever supposed to touch. This caused the entire system to perform the equivalent of a BSoD. To me, this seems like something the compiler should catch (GCC 8.2.0). If anyone knows where to report this, please either let me know or report it yourself with a link to this PR or the graphics.cpp file at commit c9a27bd45ea07a7f75ea1a5e201a9c4e6873af1e on this branch (3ds-next).