### PR TITLE
Switch/add get gamepad axis

### DIFF
--- a/platform/switch/source/objects/gamepad/gamepad.cpp
+++ b/platform/switch/source/objects/gamepad/gamepad.cpp
@@ -216,31 +216,7 @@ float Gamepad::GetAxis(uint axis)
 
 float Gamepad::GetGamepadAxis(const string & axis)
 {
-    hidScanInput();
+    float value = 0;
 
-    JoystickPosition leftJoystick, rightJoystick;
-
-    hidJoystickRead(&leftJoystick, CONTROLLER_P1_AUTO, JOYSTICK_LEFT);
-    hidJoystickRead(&rightJoystick, CONTROLLER_P1_AUTO, JOYSTICK_RIGHT);
-
-    if (axis == "leftx")
-    {
-        return (float)(leftJoystick.dx - -32766) / (32766 - -32766) * (2) + -1;
-    }
-    else if (axis == "lefty")
-    {
-        return -((float)(leftJoystick.dy - -32766) / (32766 - -32766) * (2) + -1);
-    }
-    else if (axis == "rightx")
-    {
-        return (float)(rightJoystick.dx - -32766) / (32766 - -32766) * (2) + -1;
-    }
-    else if (axis == "righty")
-    {
-        return -((float)(rightJoystick.dy - -32766) / (32766 - -32766) * (2) + -1);
-    }
-    else
-    {
-        return 0;
-    }
+    return value;
 }

--- a/platform/switch/source/objects/gamepad/gamepad.cpp
+++ b/platform/switch/source/objects/gamepad/gamepad.cpp
@@ -216,7 +216,31 @@ float Gamepad::GetAxis(uint axis)
 
 float Gamepad::GetGamepadAxis(const string & axis)
 {
-    float value = 0;
+    hidScanInput();
 
-    return value;
+    JoystickPosition leftJoystick, rightJoystick;
+
+    hidJoystickRead(&leftJoystick, CONTROLLER_P1_AUTO, JOYSTICK_LEFT);
+    hidJoystickRead(&rightJoystick, CONTROLLER_P1_AUTO, JOYSTICK_RIGHT);
+
+    if (axis == "leftx")
+    {
+        return (float)(leftJoystick.dx - -32766) / (32766 - -32766) * (2) + -1;
+    }
+    else if (axis == "lefty")
+    {
+        return -((float)(leftJoystick.dy - -32766) / (32766 - -32766) * (2) + -1);
+    }
+    else if (axis == "rightx")
+    {
+        return (float)(rightJoystick.dx - -32766) / (32766 - -32766) * (2) + -1;
+    }
+    else if (axis == "righty")
+    {
+        return -((float)(rightJoystick.dy - -32766) / (32766 - -32766) * (2) + -1);
+    }
+    else
+    {
+        return 0;
+    }
 }

--- a/platform/switch/source/objects/gamepad/wrap_gamepad.cpp
+++ b/platform/switch/source/objects/gamepad/wrap_gamepad.cpp
@@ -48,19 +48,6 @@ int gamepadGetAxis(lua_State * L)
 {
     Gamepad * self =  (Gamepad *)luaobj_checkudata(L, 1, CLASS_TYPE);
 
-    int axis = luaL_checknumber(L, 2);
-
-    float value = self->GetAxis(axis);
-
-    lua_pushnumber(L, value);
-
-    return 1;
-}
-
-int gamepadGetGamepadAxis(lua_State * L)
-{
-    Gamepad * self = (Gamepad *)luaobj_checkudata(L, 1, CLASS_TYPE);
-
     string axis = luaL_checkstring(L, 2);
 
     float value = self->GetGamepadAxis(axis);
@@ -178,6 +165,7 @@ int initGamepadClass(lua_State * L)
         { "isDown",               gamepadIsDown               },
         { "isGamepadDown",        gamepadIsGamepadDown        },
         { "isVibrationSupported", gamepadIsVibrationSupported },
+        { "getGamepadAxis",       gamepadGetAxis },
         { "setLayout",            gamepadSetLayout            },
         { "setVibration",         gamepadSetVibration         },
         { 0, 0 },

--- a/platform/switch/source/objects/gamepad/wrap_gamepad.cpp
+++ b/platform/switch/source/objects/gamepad/wrap_gamepad.cpp
@@ -48,6 +48,19 @@ int gamepadGetAxis(lua_State * L)
 {
     Gamepad * self =  (Gamepad *)luaobj_checkudata(L, 1, CLASS_TYPE);
 
+    int axis = luaL_checknumber(L, 2);
+
+    float value = self->GetAxis(axis);
+
+    lua_pushnumber(L, value);
+
+    return 1;
+}
+
+int gamepadGetGamepadAxis(lua_State * L)
+{
+    Gamepad * self = (Gamepad *)luaobj_checkudata(L, 1, CLASS_TYPE);
+
     string axis = luaL_checkstring(L, 2);
 
     float value = self->GetGamepadAxis(axis);
@@ -165,7 +178,6 @@ int initGamepadClass(lua_State * L)
         { "isDown",               gamepadIsDown               },
         { "isGamepadDown",        gamepadIsGamepadDown        },
         { "isVibrationSupported", gamepadIsVibrationSupported },
-        { "getGamepadAxis",       gamepadGetAxis },
         { "setLayout",            gamepadSetLayout            },
         { "setVibration",         gamepadSetVibration         },
         { 0, 0 },


### PR DESCRIPTION
Adds getGamepadAxis function by replacing the existing stub

See https://love2d.org/wiki/Joystick:getGamepadAxis for more details.