### PR TITLE
3DS & Switch: Clean Up Makefile LIBS Line

### DIFF
--- a/platform/3ds/Makefile
+++ b/platform/3ds/Makefile
@@ -86,7 +86,7 @@ CXXFLAGS	:= $(CFLAGS) -Wno-psabi -fno-rtti -fno-exceptions -std=gnu++14
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:= `curl-config --libs` `arm-none-eabi-pkg-config SDL_mixer` -lcitro2d
+LIBS	:= `curl-config --libs` `arm-none-eabi-pkg-config SDL_mixer` -lcitro2d -lctru
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/platform/3ds/Makefile
+++ b/platform/3ds/Makefile
@@ -86,7 +86,7 @@ CXXFLAGS	:= $(CFLAGS) -Wno-psabi -fno-rtti -fno-exceptions -std=gnu++14
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:= `curl-config --libs` `arm-none-eabi-pkg-config SDL_mixer` -lcitro2d -lctru
+LIBS	:= `curl-config --libs` `arm-none-eabi-pkg-config SDL_mixer` -lcitro2d -lcitro3d -lctru
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/platform/3ds/Makefile
+++ b/platform/3ds/Makefile
@@ -86,7 +86,7 @@ CXXFLAGS	:= $(CFLAGS) -Wno-psabi -fno-rtti -fno-exceptions -std=gnu++14
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:= -lcurl -lmbedtls -lmbedx509 -lmbedcrypto -lSDL_mixer -lmikmod -lmad -lvorbisidec -logg `sdl-config --libs` -lz -lcitro2d -lcitro3d -lctru -lm
+LIBS	:= `curl-config --libs` `arm-none-eabi-pkg-config SDL_mixer` -lcitro2d
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/platform/switch/Makefile
+++ b/platform/switch/Makefile
@@ -79,7 +79,7 @@ CXXFLAGS  :=	$(CFLAGS) -fno-rtti -fexceptions -std=gnu++14
 ASFLAGS   :=    -g $(ARCH)
 LDFLAGS   =     --specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS := -lcurl -lmbedx509 -lmbedtls -lmbedcrypto -lSDL2_mixer -lmodplug -lmpg123 -lvorbisidec -logg -lopusfile -lopus -lSDL2_ttf -lSDL2_gfx -lSDL2_image -lpng -ljpeg -lwebp `sdl2-config --libs` `freetype-config --libs`
+LIBS := `curl-config --libs` `aarch64-none-elf-pkg-config SDL2_mixer SDL2_ttf SDL2_image SDL2_gfx --libs`
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing


### PR DESCRIPTION
This will shorten the lines considerably to make them much more readable. However, we do sacrifice *knowing* what we need. The good news is the wiki already has this documented anyways so who cares.