### PR TITLE
Find font in a .bcfnt file rather than a fnt file

### DIFF
--- a/platform/3ds/source/font.cpp
+++ b/platform/3ds/source/font.cpp
@@ -3,7 +3,7 @@
 
 using namespace love;
 
-#define FONT_NOT_FOUND_STRING "Could not find font %s (not converted to fnt?)"
+#define FONT_NOT_FOUND_STRING "Could not find font %s (not converted to bcfnt?)"
 
 Font::Font(const std::string & path, float size) : buffer(C2D_TextBufNew(4096)),
                                                    size(size)
@@ -38,7 +38,7 @@ FontHandle Font::LoadFromPath(const std::string & path)
     std::string translation;
 
     if (pos != std::string::npos)
-        translation = (path.substr(0, pos) + "fnt");
+        translation = (path.substr(0, pos) + "bcfnt");
 
     if (std::filesystem::exists(translation))
         return C2D_FontLoad(translation.c_str());


### PR DESCRIPTION
Really quick fix, I haven't tested it or anything, but the diff should be really self explanatory.

```
$(BUILD)/%.bcfnt:
#---------------------------------------------------------------------------------
	@echo "$(notdir $*.ttf) -> $(notdir $*.bcfnt)"
	@mkbcfnt $*.ttf -o $(BUILD)/$*.bcfnt
	@rm "$(BUILD)/$*.ttf"
```
The Makefile from the 3DS build template currently outputs a .bcfnt file, but the LovePotion code currently looks for a .fnt file. I just updated the error message and the actual path to reflect that.