### PR TITLE
3ds: battery level fix

### DIFF
--- a/platform/ctr/source/modules/system_ext.cpp
+++ b/platform/ctr/source/modules/system_ext.cpp
@@ -12,10 +12,7 @@ System<>::PowerState System<Console::CTR>::GetPowerInfo(uint8_t& percent) const
     uint8_t batteryState = 0;
     PowerState state     = PowerState::POWER_UNKNOWN;
 
-    uint8_t percentRaw = 0;
-    MCUHWC_GetBatteryLevel(&percentRaw);
-
-    percent = (percentRaw / 0xFF) * 100;
+    MCUHWC_GetBatteryLevel(&percent);
     PTMU_GetBatteryChargeState(&batteryState);
 
     state = (batteryState) ? PowerState::POWER_CHARGING : PowerState::POWER_BATTERY;


### PR DESCRIPTION
## Summary of the Pull Request
This pull request fixes the `love.system.getPowerInfo()` function on the 3DS. It turns out that `MCUHWC_GetBatteryLevel(&uint8_t)` returns a number from 0-100 already and does not need to be converted to a percentage, so I just modified the GetPowerInfo function to return that number directly.

## Validation Steps
I tested this on my New Nintendo 3DS XL running the latest firmware (J), and compared it to the Rosalina menu at multiple percentages and charging states.

Here is the code I used to validate:
```lua
local font
function love.load()
    font = love.graphics.newFont("standard", 30)
end
function love.draw(screen)
    local state, pct = love.system.getPowerInfo()
    love.graphics.setFont(font)
    love.graphics.print(state .. " | " .. tostring(pct), 10, 180)
end
```

## Checklist
- [x] Closes N/A
- [x] Successfully builds

## Screenshots
![image0](https://github.com/user-attachments/assets/29eea5d7-95fb-4414-9a59-a8473c77314e)
You can see at the bottom right, Luma/Rosalina reports the same percentage as the game does.

Let me know if I overlooked anything, and thanks for this awesome project!